### PR TITLE
Permit to change the mask dinamically

### DIFF
--- a/lib/flutter_masked_text.dart
+++ b/lib/flutter_masked_text.dart
@@ -23,7 +23,8 @@ class MaskedTextController extends TextEditingController {
   }
 
   void updateMask(String mask) {
-    this.text = this._applyMask(mask, this.text);
+    this.mask = mask;
+    this.updateText(this.text);
   }
 
   @override

--- a/lib/flutter_masked_text.dart
+++ b/lib/flutter_masked_text.dart
@@ -1,7 +1,6 @@
 library flutter_masked_text;
 
 import 'package:flutter/material.dart';
-import 'dart:math';
 
 class MaskedTextController extends TextEditingController {
   MaskedTextController({String text, this.mask, Map<String, RegExp> translator})
@@ -15,12 +14,16 @@ class MaskedTextController extends TextEditingController {
     this.updateText(this.text);
   }
 
-  final String mask;
+  String mask;
 
   Map<String, RegExp> translator;
 
   void updateText(String text) {
     this.text = this._applyMask(this.mask, text);
+  }
+
+  void updateMask(String mask) {
+    this.text = this._applyMask(mask, this.text);
   }
 
   @override

--- a/test/flutter_masked_text_test.dart
+++ b/test/flutter_masked_text_test.dart
@@ -16,9 +16,9 @@ void main() {
 
       expect(cpfController.text, '123.456.789-01');
 
-      cpfController.updateMask('000.000.000.00');
+      cpfController.updateMask('000.000.0000-0');
 
-      expect(cpfController.text, '123.456.789.01');
+      expect(cpfController.text, '123.456.7890-1');
     });
 
     test('abc123 with mask AAA results abc', () {

--- a/test/flutter_masked_text_test.dart
+++ b/test/flutter_masked_text_test.dart
@@ -9,6 +9,7 @@ void main() {
 
       expect(cpfController.text, '123.456.789-01');
     });
+
     test('12345678901 with mask 000.000.000-00 and changed results 123.456.789.01', () {
       var cpfController =
           new MaskedTextController(text: '12345678901', mask: '000.000.000-00');

--- a/test/flutter_masked_text_test.dart
+++ b/test/flutter_masked_text_test.dart
@@ -3,11 +3,21 @@ import 'package:flutter_masked_text/flutter_masked_text.dart';
 
 void main() {
   group('masked text', () {
-    test('12345678901 with mask 000.000.000-00 resunts 123.456.789-01', () {
+    test('12345678901 with mask 000.000.000-00 results 123.456.789-01', () {
       var cpfController =
           new MaskedTextController(text: '12345678901', mask: '000.000.000-00');
 
       expect(cpfController.text, '123.456.789-01');
+    });
+    test('12345678901 with mask 000.000.000-00 and changed results 123.456.789.01', () {
+      var cpfController =
+          new MaskedTextController(text: '12345678901', mask: '000.000.000-00');
+
+      expect(cpfController.text, '123.456.789-01');
+
+      cpfController.updateMask('000.000.000.00');
+
+      expect(cpfController.text, '123.456.789.01');
     });
 
     test('abc123 with mask AAA results abc', () {


### PR DESCRIPTION
This is now compatible with mask changing behavior, so the dev can choose which mask he will present. For example, multivalued input fields.