### PR TITLE
fix: left symble removable bug.

### DIFF
--- a/lib/flutter_masked_text.dart
+++ b/lib/flutter_masked_text.dart
@@ -145,7 +145,7 @@ class MoneyMaskedTextController extends TextEditingController {
     }
   }
 
-  double get numberValue => double.parse(_getSanitizedText(this.text)) / 100.0;
+  double get numberValue => (double.tryParse(_getSanitizedText(this.text)) ?? 0.0) / 100.0;
 
 //  @override
 //  set text(String newText) {


### PR DESCRIPTION
I think, in many cases, left money symbol is unexpected to be removed. 