### PR TITLE
Fixed: updateText crashes when text is Null

### DIFF
--- a/lib/flutter_masked_text.dart
+++ b/lib/flutter_masked_text.dart
@@ -32,8 +32,10 @@ class MaskedTextController extends TextEditingController {
   String _lastUpdatedText = '';
 
   void updateText(String text) {
-    this.text = this._applyMask(this.mask, text);
-    this._lastUpdatedText = this.text;
+    if(text != null){
+      this.text = this._applyMask(this.mask, text);
+      this._lastUpdatedText = this.text;
+    }
   }
 
   void updateMask(String mask) {


### PR DESCRIPTION
This piece of code solves the crash when the text is null.